### PR TITLE
Fix solr volume not persisting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - "9983:8983"
     volumes:
-      - data:/opt/solr/server/solr/mycores
+      - data:/var/solr
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate


### PR DESCRIPTION
Fixes solr not persisting volumes between container restarts.

Hero:
- Start the search-stack.
- Using postman or the solr admin UI, create a configuration
- Search solr through the admin ui to make sure the config is saved
- Stop the stack
- Start the stack
- Search solr through the admin ui to make sure the previous config is still there