### PR TITLE
Fix gradle deploy task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ task listDependencies(type: DependencyReportTask)
 
 task deploy(type: Exec) {
     dependsOn build
-    commandLine "groovy deploy.groovy"
+    commandLine "groovy", "deploy.groovy"
 }
 
 assemble.finalizedBy("docker")


### PR DESCRIPTION
The commandLine call expects args to be passed in when an executable is called. 

https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Exec.html