### PR TITLE
Fix remote deploy solr persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - "9983:8983"
     volumes:
-      - data:/var/solr
+      - "data:/var/solr"
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate
@@ -38,6 +38,7 @@ networks:
     external: true
 volumes:
   data:
+    driver: local
 configs:
   search_config:
     file: ./configs/search_config.yml


### PR DESCRIPTION
Fixes solr data not persisting between service restarts. (not sure why this fixes the issue but it does)

@emmberk @ahoffer @jhunzik 

To hero:
Deploy remotely
Add an entry to solr
Restart the stack
Query solr and verify the previous entry is there