### PR TITLE
Add code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ For more information about spotless checks see
 * The integration tests require a Docker daemon.
 * To skip integration tests, add `-PskipITests`.
 
+##### Code Coverage
+Jacoco provides code coverage under `build/reports/jacoco`. Jacoco tasks are run as part of the test task.
+
 ## Running
 ### Configuring
 1. The service can be configured with an external configuration file that will be applied to the docker container during deployment.

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,9 @@ buildscript {
 
 plugins {
     id "com.diffplug.gradle.spotless" version "3.25.0"
-    id "java"
     id "com.palantir.docker" version "0.22.1"
+    id "jacoco"
+    id "java"
     id "maven"
     id "org.owasp.dependencycheck" version "5.2.2"
     id "org.springframework.boot" version "${springBootVersion}"
@@ -80,6 +81,30 @@ targetCompatibility = 1.11
 
 test {
     useJUnitPlatform()
+    finalizedBy(['jacocoTestReport', 'jacocoTestCoverageVerification'])
+}
+
+jacoco {
+    toolVersion = "0.8.5"
+    reportsDir = file("$buildDir/reports/jacoco")
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.destination file("${buildDir}/reports/jacoco")
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.72
+            }
+        }
+    }
 }
 
 spotless {
@@ -156,5 +181,5 @@ task deploy(type: Exec) {
 }
 
 assemble.finalizedBy("docker")
-build.finalizedBy("docker")
+build.finalizedBy(['docker'])
 bootRun.dependsOn(build)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.caching=true
+org.gradle.daemon=true
+org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Adds jacoco
- Upgrades gradle wrapper
- Add gradle properties file

For some reason coverage includes itests. I'm not sure if its the naming schema we are using.

To hero:
- Full build
- Verify files in `build/reports/jacoco`, mainly index.html